### PR TITLE
feat: redesign TiUD 2026 popup and wire up registration form

### DIFF
--- a/pingcap-jp/css/templates/tidb-user-day-2026.scss
+++ b/pingcap-jp/css/templates/tidb-user-day-2026.scss
@@ -188,6 +188,247 @@
 		}
 	}
 
+	.o-modal {
+		display: none;
+		position: fixed;
+		inset: 0;
+		z-index: 100000;
+		align-items: center;
+		justify-content: center;
+		padding: 24px;
+
+		&.is-active {
+			display: flex;
+		}
+	}
+
+	.o-modal_wrap {
+		position: relative;
+		z-index: 2;
+		width: min(900px, 100%);
+		max-width: 900px;
+	}
+
+	.o-modal_inner {
+		width: 100%;
+	}
+
+	.o-modal_bg {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.65);
+		z-index: 1;
+		cursor: pointer;
+	}
+
+	.o-modal_close {
+		position: absolute;
+		top: 20px;
+		right: 20px;
+		z-index: 3;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3em;
+		padding: 0;
+		border: 0;
+		background: none;
+		color: #6b7280;
+		font-size: 16px;
+		font-weight: 500;
+		line-height: 1;
+		cursor: pointer;
+		transition: color 0.2s ease;
+
+		&:hover {
+			color: #1f2937;
+		}
+	}
+
+	.tiud-popup__wrap {
+		background: transparent;
+		box-shadow: none;
+		padding: 0;
+	}
+
+	.tiud-popup__content {
+		position: relative;
+		container-type: inline-size;
+	}
+
+	.tiud-popup__inner {
+		position: relative;
+		aspect-ratio: 1500 / 850;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		padding: 14cqw 11cqw 15cqw;
+		background-repeat: no-repeat;
+		background-size: cover;
+		background-position: center;
+		box-sizing: border-box;
+		border-radius: 8px;
+	}
+
+	.tiud-popup__body {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
+	.tiud-popup__title {
+		display: flex;
+		justify-content: center;
+		gap: 0.4em;
+		margin: 0 0 1.6cqw;
+		font-size: 20px;
+		font-weight: 700;
+		line-height: 1.3;
+		color: #17263f;
+	}
+
+	.tiud-popup__gift {
+		font-size: 1.3em;
+	}
+
+	.tiud-popup__highlight {
+		margin: 0 0 0.8cqw;
+		font-size: 2.4cqw;
+		font-weight: 700;
+		color: #1877c9;
+	}
+
+	.tiud-popup__lead {
+		margin: 0 0 2.4cqw;
+		font-size: 16px;
+		line-height: 1.5;
+		color: #1d2b3a;
+
+		strong {
+			font-weight: 700;
+		}
+	}
+
+	.tiud-popup__cta {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.6em;
+		min-width: 22cqw;
+		padding: 1.2cqw 3cqw;
+		background: linear-gradient(180deg, #2f7fd6 0%, #1b5fb0 100%);
+		border: 1px solid rgba(255, 255, 255, 0.6);
+		border-radius: 6px;
+		box-shadow: 0 3px 8px rgba(0, 0, 0, 0.2);
+		color: #fff;
+		font-size: 1.8cqw;
+		font-weight: 700;
+		text-decoration: none;
+		cursor: pointer;
+		transition: filter 0.2s ease;
+
+		&::after {
+			content: "▶";
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 16px;
+			height: 16px;
+			border-radius: 50%;
+			background: rgba(255, 255, 255, 0.25);
+			font-size: 0.65em;
+			padding-top: 2px;
+			padding-left: 2px;
+		}
+
+		&:hover {
+			filter: brightness(1.08);
+		}
+	}
+
+	.tiud-popup__notes {
+		position: absolute;
+		right: 6cqw;
+		bottom: 10px;
+		text-align: right;
+		color: #5a6b7b;
+		font-size: 12px;
+		line-height: 1.5;
+
+		p {
+			font-size: 12px;
+			margin: 0;
+			white-space: nowrap;
+		}
+	}
+
+	@container (max-width: 560px) {
+		.o-modal_close {
+			top: 12px;
+			right: 14px;
+			font-size: 13px;
+		}
+
+		.tiud-popup__inner {
+			aspect-ratio: auto;
+			min-height: 300px;
+			padding: 42px 20px 28px;
+		}
+
+		.tiud-popup__title {
+			font-size: 15px;
+			margin-bottom: 10px;
+		}
+
+		.tiud-popup__highlight {
+			font-size: 17px;
+			margin-bottom: 6px;
+		}
+
+		.tiud-popup__lead {
+			font-size: 13px;
+			margin-bottom: 18px;
+		}
+
+		.tiud-popup__cta {
+			min-width: 160px;
+			padding: 10px 22px;
+			font-size: 15px;
+		}
+
+		.tiud-popup__notes {
+			position: static;
+			right: auto;
+			bottom: auto;
+			margin-top: 18px;
+			font-size: 10px;
+
+			p {
+				white-space: normal;
+			}
+		}
+	}
+
+	.tiud-floating-cta {
+		display: none;
+		position: fixed;
+		right: 20px;
+		bottom: 40px;
+		z-index: 1100;
+		background: #00d1e6;
+		color: #00363e;
+		padding: 12px 14px;
+		border-radius: 6px;
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+		text-decoration: none;
+		font-weight: 700;
+
+		&.is-visible {
+			display: inline-block;
+		}
+	}
+
 	.banner {
 		position: relative;
 		padding-top: 180px;
@@ -197,7 +438,7 @@
 		h1 {
 			color: #fff;
 			line-height: 1.2;
-			background: linear-gradient(90deg, #1DECFB 0%, #0B5CE6 78.85%);
+			background: linear-gradient(90deg, #1decfb 0%, #0b5ce6 78.85%);
 			-webkit-background-clip: text;
 			-webkit-text-fill-color: transparent;
 			@include media-min($large) {
@@ -213,7 +454,7 @@
 		li {
 			color: #b9c2ca;
 			font-size: 22px;
-			@include media-min($medium){
+			@include media-min($medium) {
 				font-size: 26px;
 			}
 
@@ -519,6 +760,13 @@
 
 			margin-bottom: 32px;
 		}
+		.block-logos__logo-grid {
+			display: flex;
+			flex-wrap: wrap;
+		}
+		.block-logos__logo-image {
+			height: 42px;
+		}
 	}
 
 	.campaign {
@@ -543,7 +791,7 @@
 			color: #a2adb9;
 			font-size: 300;
 		}
-		&-desc{
+		&-desc {
 			margin-top: 60px;
 		}
 		.campaign-content {
@@ -551,11 +799,11 @@
 			flex-direction: column;
 			gap: 32px;
 			align-items: center;
-			@include media-min($medium){
+			@include media-min($medium) {
 				flex-direction: row;
 			}
 		}
-		.campaign-text{
+		.campaign-text {
 			flex: 1;
 		}
 		.campaign-tabs__nav {

--- a/pingcap-jp/templates/page-tidb-user-day-2026.php
+++ b/pingcap-jp/templates/page-tidb-user-day-2026.php
@@ -12,6 +12,35 @@ get_header();
 
 ?>
 <div class="tmpl-tidb-user-day-2026">
+    <?php $tiud_bg = get_template_directory_uri() . '/media/images/20260719-223627.jpeg'; ?>
+    <button type="button" class="tiud-popup-trigger js-modal" data-modal="tiud-popup-modal" style="display:none;"></button>
+
+    <div class="o-modal" data-modal-id="tiud-popup-modal">
+        <div class="o-modal_wrap tiud-popup__wrap">
+            <div class="o-modal_inner">
+                <div class="tiud-popup__content">
+                    <div class="tiud-popup__inner" style="background-image: url('https://static.pingcap.co.jp/files/2026/07/21103551/20260719-223627.jpeg');">
+                        <button type="button" class="o-modal_close js-modal__close" aria-label="閉じる">× close</button>
+                        <div class="tiud-popup__body">
+                            <h3 class="tiud-popup__title"><span class="tiud-popup__gift">🎁</span> TiDB User Day 2026 早期ご登録キャンペーン開催中！</h3>
+                            <p class="tiud-popup__highlight">先着200名様限定！</p>
+                            <p class="tiud-popup__lead">TiDB User Day 2026 にご登録いただいた方の中から、<br>抽選で<strong>50名様にAmazonデジタルギフトカード（1,000円分）</strong>をプレゼント！</p>
+                            <a class="tiud-popup__cta js-modal__close js--trigger-form-modal" data-form-id="2c77365f-067c-4762-9c04-db33bd056bd5">今すぐ登録</a>
+                        </div>
+                        <div class="tiud-popup__notes">
+                            <p>※キャンペーン主催：PingCAP株式会社</p>
+                            <p>※AmazonはAmazon.com, Inc.またはその関連会社の商標です。</p>
+                            <p>※当選者の発表は、イベント終了後、ご登録いただいたメールアドレスへのご連絡をもって代えさせていただきます。</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="o-modal_bg js-modal__close"></div>
+    </div>
+
+    <!-- Floating CTA shown after popup is closed -->
+    <a id="tiud-floating-cta" class="tiud-floating-cta" href="#campaign" aria-hidden="true">早期登録キャンペーン</a>
     <div class="banner">
         <?php echo ACF::get_field_string('banner_content'); ?>
     </div>
@@ -288,6 +317,55 @@ get_header();
             navEl.classList.remove('active');
         })
     });
+</script>
+
+<script>
+    (function() {
+        const modal = document.querySelector('.o-modal[data-modal-id="tiud-popup-modal"]');
+        const floating = document.getElementById('tiud-floating-cta');
+
+        function showFloating() {
+            if (!floating) return;
+            floating.setAttribute('aria-hidden', 'false');
+            floating.classList.add('is-visible');
+        }
+
+        function hideFloating() {
+            if (!floating) return;
+            floating.setAttribute('aria-hidden', 'true');
+            floating.classList.remove('is-visible');
+        }
+
+        function openModal() {
+            if (!modal) return;
+            modal.classList.add('is-active');
+        }
+
+        function closeModal() {
+            if (!modal) return;
+            modal.classList.remove('is-active');
+        }
+
+        document.addEventListener('click', function(e) {
+            const closeEl = e.target.closest('.js-modal__close');
+            if (closeEl) {
+                closeModal();
+                showFloating();
+            }
+        });
+
+        if (floating) {
+            floating.addEventListener('click', function(e) {
+                e.preventDefault();
+                openModal();
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            hideFloating();
+            setTimeout(openModal, 300);
+        });
+    })();
 </script>
 
 <script>


### PR DESCRIPTION
- Redesign campaign popup to match design spec: overlay text on the frosted-panel background image, blue highlight, gradient CTA with play icon, "× close" text button, and footer notes
- Make popup responsive via container queries (cqw scaling on desktop, natural flow below 560px)
- Open the HubSpot registration form (form id 2c77365f-067c-4762-9c04-db33bd056bd5) when clicking 今すぐ登録, reusing the existing js--trigger-form-modal mechanism
- Right-side floating CTA now reopens the popup on click
- Auto-open the popup on every page load (drop localStorage suppression)
- Remove a stray block accidentally pasted after the template's SCSS wrapper (old style.css header + unscoped duplicate rules)