### PR TITLE
style: enlarge TiUD 2026 agenda tab nav items

### DIFF
--- a/pingcap-jp/css/templates/tidb-user-day-2026.scss
+++ b/pingcap-jp/css/templates/tidb-user-day-2026.scss
@@ -722,14 +722,17 @@
 		}
 
 		.agenda-tabs__nav-item {
-			padding: 4px 24px;
+			padding: 6px 42px;
 			background: rgba(255, 255, 255, 0.1);
 			border: 1px solid #fff;
 			color: #fff;
 			cursor: pointer;
 			transition: all 0.3s ease;
-			font-size: 22px;
+			font-size: 28px;
 			font-weight: 500;
+			@include media-min($medium) {
+				padding: 6px 92px;
+			}
 		}
 
 		.agenda-tabs__nav-item:hover {


### PR DESCRIPTION
## What

Increase the size of the agenda tab nav items on the TiDB User Day 2026 page:

- Padding: `4px 24px` → `6px 42px`
- Font size: `22px` → `28px`
- Wider horizontal padding (`6px 92px`) on medium+ screens

## Why

Make the agenda tab navigation more prominent and easier to tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)